### PR TITLE
Remove redundant `extern` storage class specifier

### DIFF
--- a/src/myrustlib/api.h
+++ b/src/myrustlib/api.h
@@ -1,4 +1,13 @@
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 char * string_from_rust();
 int32_t random_number();
 void run_threads();
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/myrustlib/api.h
+++ b/src/myrustlib/api.h
@@ -1,4 +1,4 @@
 #include <stdint.h>
-extern char * string_from_rust();
-extern int32_t random_number();
-extern void run_threads();
+char * string_from_rust();
+int32_t random_number();
+void run_threads();


### PR DESCRIPTION
`extern` in C and C++ is used to syntactically distinguish declarations from
definitions for the purpose of linkage. This isn’t necessary for function
declarations: they always have external linkage (unless declared `static` or in
an unnamed namespace).

Since the rules are confusing, I suggest removing the redundant qualifier, as
its presence here falsely suggests that it is necessary and confers semantic
meaning.