### PR TITLE
Fix the format of staticlib on Windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,6 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 LIBDIR = myrustlib/target/$(TARGET)/release
-STATLIB = $(LIBDIR)/myrustlib.a
+STATLIB = $(LIBDIR)/libmyrustlib.a
 PKG_LIBS = -L$(LIBDIR) -lmyrustlib -lws2_32 -ladvapi32 -luserenv
 
 all: clean

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,6 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 LIBDIR = myrustlib/target/$(TARGET)/release
-STATLIB = $(LIBDIR)/myrustlib.lib
+STATLIB = $(LIBDIR)/myrustlib.a
 PKG_LIBS = -L$(LIBDIR) -lmyrustlib -lws2_32 -ladvapi32 -luserenv
 
 all: clean


### PR DESCRIPTION
After rust-lang/rust#70937, Rust generates `.a` extention of staticlib for `*-pc-windows-gnu` targets.

Though I'm sending this pull request, I have no idea why AppVeyor still passes on master, btw...