### PR TITLE
Add -lntdll to fix build failure with Rust 1.70 on Windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,7 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 LIBDIR = myrustlib/target/$(TARGET)/release
 STATLIB = $(LIBDIR)/libmyrustlib.a
-PKG_LIBS = -L$(LIBDIR) -lmyrustlib -lws2_32 -ladvapi32 -lgdi32 -lbcrypt -lcrypt32 -luserenv
+PKG_LIBS = -L$(LIBDIR) -lmyrustlib -lws2_32 -ladvapi32 -lgdi32 -lbcrypt -lcrypt32 -luserenv -lntdll
 
 all: clean rustup
 


### PR DESCRIPTION
@jeroen 
Sorry to bother you. Windows builds will be broken when Rust 1.70 rolls out to the CRAN Windows server or GHA Windows runner. Adding this option can fix the failure. I guess it's not very soon when it happens on CRAN, but, on GHA the image with Rust 1.70 is already rolling out (at the moment, 16.51% according to [here](https://github.com/actions/runner-images#available-images)). So, R-universe will soon start to see such failures.

Note that, on R <= 4.2, GNU linker emits warnings, and it seems there's no way to stop it. So, depending on whether warnings are treated as errors, it still fails if this option is added.

For more details, please see: https://stat.ethz.ch/pipermail/r-package-devel/2023q2/009229.html (This contains one mistake. I found "it's the case on GitHub Actions" is not true. Sorry)

<details>
<summary>the error message</summary>
```
gcc -shared -s -static-libgcc -o hellorust.dll tmp.def wrapper.o -Lmyrustlib/target/x86_64-pc-windows-gnu/release -lmyrustlib -lws2_32 -ladvapi32 -lgdi32 -lbcrypt -lcrypt32 -luserenv -LC:/rtools43/x86_64-w64-mingw32.static.posix/lib/x64 -LC:/rtools43/x86_64-w64-mingw32.static.posix/lib -LC:/PROGRA~1/R/R-43~1.0/bin/x64 -lR
C:\rtools43\x86_64-w64-mingw32.static.posix\bin/ld.exe: myrustlib/target/x86_64-pc-windows-gnu/release/libmyrustlib.a(std-ca5208825e97b4ba.std.687851ba-cgu.0.rcgu.o): in function `std::sys::windows::fs::open_link_no_reparse':
/rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys\windows/fs.rs:800: undefined reference to `NtCreateFile'
C:\rtools43\x86_64-w64-mingw32.static.posix\bin/ld.exe: /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys\windows/fs.rs:829: undefined reference to `RtlNtStatusToDosError'
C:\rtools43\x86_64-w64-mingw32.static.posix\bin/ld.exe: myrustlib/target/x86_64-pc-windows-gnu/release/libmyrustlib.a(std-ca5208825e97b4ba.std.687851ba-cgu.0.rcgu.o): in function `std::sys::windows::handle::Handle::synchronous_read':
/rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys\windows/handle.rs:241: undefined reference to `NtReadFile'
C:\rtools43\x86_64-w64-mingw32.static.posix\bin/ld.exe: /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys\windows/handle.rs:272: undefined reference to `RtlNtStatusToDosError'
C:\rtools43\x86_64-w64-mingw32.static.posix\bin/ld.exe: myrustlib/target/x86_64-pc-windows-gnu/release/libmyrustlib.a(std-ca5208825e97b4ba.std.687851ba-cgu.0.rcgu.o): in function `std::sys::windows::handle::Handle::synchronous_write':
/rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys\windows/handle.rs:290: undefined reference to `NtWriteFile'
C:\rtools43\x86_64-w64-mingw32.static.posix\bin/ld.exe: /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys\windows/handle.rs:318: undefined reference to `RtlNtStatusToDosError'
collect2.exe: error: ld returned 1 exit status
no DLL was created
ERROR: compilation failed for package 'hellorust'
```
</details>