### PR TITLE
fix Is the CString need to be freed? #10

### DIFF
--- a/src/myrustlib/src/hello.rs
+++ b/src/myrustlib/src/hello.rs
@@ -1,11 +1,8 @@
-use std;
 use std::ffi::CString;
 use std::os::raw::c_char;
 
 #[no_mangle]
 pub extern fn string_from_rust() -> *const c_char {
     let s = CString::new("Hello ピカチュウ !").unwrap();
-    let p = s.as_ptr();
-    std::mem::forget(s);
-    p
+    s.into_raw()
 }


### PR DESCRIPTION
Fixes #10 

We have been up and down, and everywhere with this issue.
This PR contains how it really ought to be done. Note that the documentation for `std::mem::forget` even recommends this approach.