### PR TITLE
Free the leaked rust `CString`

### DIFF
--- a/src/myrustlib/api.h
+++ b/src/myrustlib/api.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 char * string_from_rust(void);
+void free_string_from_rust(char*);
 int32_t random_number(void);
 void run_threads(void);
 

--- a/src/myrustlib/src/hello.rs
+++ b/src/myrustlib/src/hello.rs
@@ -2,7 +2,12 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 
 #[no_mangle]
-pub extern fn string_from_rust() -> *const c_char {
+pub extern "C" fn string_from_rust() -> *const c_char {
     let s = CString::new("Hello ピカチュウ !").unwrap();
     s.into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn free_string_from_rust(ptr: *mut c_char) {
+    let _ = unsafe { CString::from_raw(ptr) };
 }

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -7,7 +7,11 @@
 
 // Actual Wrappers
 SEXP hello_wrapper(void){
-  return Rf_ScalarString(Rf_mkCharCE(string_from_rust(), CE_UTF8));
+  char* hello_rust = string_from_rust();
+  SEXP hello_world_string = PROTECT(Rf_mkCharCE(hello_rust, CE_UTF8));
+  free_string_from_rust(hello_rust);
+  UNPROTECT(1);
+  return Rf_ScalarString(hello_world_string);
 }
 
 SEXP random_wrapper(void){


### PR DESCRIPTION
In #10, I thought, the main concern was the quality of the leaked pointer.
But as per @yutannihilation's comment in #20, and after reading the source code for `Rf_mkCharCE`, I believe the string needs to be deallocated.

`Rf_mkCharCE` calls `Rf_mkCharLenCE`, which in turn allocates an R `CHARSXP` and then uses `memcpy`. But it does not deallocate the string using `R_free`. Even more, Rust's documentation for `CString` explicitly states, that one _must not_ deallocate using C's `free`, which is what `R_free` is.

This does make the example more involved, but this pattern is very important. `into_raw` leaks what I (and a few others) call an Owned Pointer. And an owned pointer entails that a deallocation by `from_raw` should happen somewhere. Same pattern is observed with `Box<T>`. 