### PR TITLE
refactor: simplify Makevars files

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -4,7 +4,7 @@ PKG_CFLAGS = -pthread
 PKG_CPPFLAGS = -DSTRICT_R_HEADERS -DR_NO_REMAP
 PKG_LIBS = -L$(LIBDIR) -lmyrustlib -lresolv -pthread
 
-all: $(SHLIB) cleanup
+all: cleanup
 
 $(SHLIB): $(STATLIB)
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -4,7 +4,7 @@ STATLIB = $(LIBDIR)/libmyrustlib.a
 PKG_CPPFLAGS = -DSTRICT_R_HEADERS -DR_NO_REMAP
 PKG_LIBS = -L$(LIBDIR) -lmyrustlib -lws2_32 -ladvapi32 -lgdi32 -lbcrypt -lcrypt32 -luserenv -lntdll
 
-all: $(SHLIB) cleanup
+all: cleanup
 
 $(SHLIB): $(STATLIB)
 


### PR DESCRIPTION
IIUC, the `all` target does not need to depends on `$(SHLIB)` sinse `cleanup` already depends on `$(SHLIB)`.