### PR TITLE
ci: Add Linux Arm runner

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -16,13 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: macos-15,       r: 'next'}
-          - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: 'devel'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - { os: macos-latest,     r: 'release'  }
+          - { os: macos-15,         r: 'next'     }
+          - { os: windows-latest,   r: 'release'  }
+          - { os: windows-latest,   r: 'devel'    }
+          - { os: ubuntu-latest,    r: 'devel', http-user-agent: 'release' }
+          - { os: ubuntu-latest,    r: 'release'  }
+          - { os: ubuntu-latest,    r: 'oldrel-1' }
+          - { os: ubuntu-24.04-arm, r: 'release'  }
+          - { os: windows-11-arm,   r: 'release'  }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -30,23 +32,39 @@ jobs:
 
     steps:
       - name: Add more rust targets
-        if: runner.os == 'windows'
+        if: ${{ runner.os == 'windows' && runner.arch == 'X64' }}
         run: rustup target add x86_64-pc-windows-gnu
+      
+      - name: Install Rust on Arm Windows
+        if: ${{ runner.os == 'windows' && runner.arch == 'ARM64' }}
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > tmp.sh
+          sh ./tmp.sh -y --profile minimal --target aarch64-pc-windows-gnullvm
+          echo ${HOME}/.cargo/bin >> $GITHUB_PATH
+        shell: bash
 
       - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
+        # TODO: skip installation on Windows Arm64 and use the default installation
+        if: ${{ !(runner.os == 'windows' && runner.arch == 'ARM64') }}
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        if: ${{ !(runner.os == 'windows' && runner.arch == 'ARM64') }}
         with:
           extra-packages: any::rcmdcheck
           needs: check
+
+        # TODO: it seems pak doesn't support Windows Arm64
+      - name: Install
+        if: ${{ runner.os == 'windows' && runner.arch == 'ARM64' }}
+        run: Rscript -e 'install.packages("rcmdcheck", repos="https://cloud.r-project.org")'
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,6 @@ jobs:
           - { os: ubuntu-latest,    r: 'release'  }
           - { os: ubuntu-latest,    r: 'oldrel-1' }
           - { os: ubuntu-24.04-arm, r: 'release'  }
-          - { os: windows-11-arm,   r: 'release'  }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -51,23 +50,15 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
-        # TODO: skip installation on Windows Arm64 and use the default installation
-        if: ${{ !(runner.os == 'windows' && runner.arch == 'ARM64') }}
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        if: ${{ !(runner.os == 'windows' && runner.arch == 'ARM64') }}
         with:
           extra-packages: any::rcmdcheck
           needs: check
-
-        # TODO: it seems pak doesn't support Windows Arm64
-      - name: Install
-        if: ${{ runner.os == 'windows' && runner.arch == 'ARM64' }}
-        run: Rscript -e 'install.packages("rcmdcheck", repos="https://cloud.r-project.org")'
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,19 +31,7 @@ jobs:
 
     steps:
       - name: Add more rust targets
-        if: ${{ runner.os == 'windows' && runner.arch == 'X64' }}
         run: rustup target add x86_64-pc-windows-gnu
-      
-      - name: Install Rust on Arm Windows
-        if: ${{ runner.os == 'windows' && runner.arch == 'ARM64' }}
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > tmp.sh
-          sh ./tmp.sh -y --profile minimal --target aarch64-pc-windows-gnullvm
-          rm tmp.sh
-
-          # make cargo available on R CMD check
-          echo ${HOME}/.cargo/bin >> $GITHUB_PATH
-        shell: bash
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,6 +31,7 @@ jobs:
 
     steps:
       - name: Add more rust targets
+        if: runner.os == 'windows'
         run: rustup target add x86_64-pc-windows-gnu
 
       - uses: actions/checkout@v3

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,6 +40,9 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > tmp.sh
           sh ./tmp.sh -y --profile minimal --target aarch64-pc-windows-gnullvm
+          rm tmp.sh
+
+          # make cargo available on R CMD check
           echo ${HOME}/.cargo/bin >> $GITHUB_PATH
         shell: bash
 


### PR DESCRIPTION
edit: I found it's too difficult to test Windows ARM at the moment. So, this pull request was changed to just adding a `ubuntu-24.04-arm` runner.

~~GitHub now provides Windows Arm64 runner.~~

~~https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/~~

~~I know hellorust had been ready for Arm64 from a long ago, so, I expected this pull request was just for ensuring it. However, it seems the R installation reports `R.version$platform` as `x86_64-w64-mingw32`, which makes this logic fail. So, please do not merge this for now.~~

https://github.com/r-rust/hellorust/blob/0f2dc03b5d1272124bbf53ae182b4993f6d53b73/tools/rustarch.R#L3-L4